### PR TITLE
ignore package suffix .test

### DIFF
--- a/pkg/importchecker/domain/path.go
+++ b/pkg/importchecker/domain/path.go
@@ -3,6 +3,13 @@ package domain
 import "strings"
 
 type Path string
+
+func NewPath(path string) Path {
+	// NOTE: path may have suffix .test if the file is *_test.go and package is `main`.
+	// Since this suffix is nothing to do with the affinity rules, we ignore it.
+	return Path(strings.TrimSuffix(path, ".test"))
+}
+
 type Name string
 type PathPrefix string
 

--- a/pkg/importchecker/domain/path_test.go
+++ b/pkg/importchecker/domain/path_test.go
@@ -6,6 +6,33 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestNewPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected Path
+	}{
+		{
+			name:     "create a path",
+			path:     "foo/bar",
+			expected: Path("foo/bar"),
+		},
+		{
+			name:     "suffix .test is ignored",
+			path:     "foo/bar.test",
+			expected: Path("foo/bar"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := NewPath(tt.path)
+
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
 func TestPathPrefixContains(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/importchecker/domain/rules_test.go
+++ b/pkg/importchecker/domain/rules_test.go
@@ -108,38 +108,47 @@ func TestAntiAffinityGroupRuleCheckOK(t *testing.T) {
 		{
 			name: "path is in selfPathPrefix",
 			rule: lo.Must(NewAntiAffinityGroupRule(
-				Path("foo/bar/baz/quux"),
+				NewPath("foo/bar/baz/quux"),
 				PathPrefix("foo/bar"),
 				[]Name{},
 			)),
-			path: "foo/bar/baz/hoge",
+			path: NewPath("foo/bar/baz/hoge"),
 		},
 		{
 			name: "path is not in group",
 			rule: lo.Must(NewAntiAffinityGroupRule(
-				Path("foo/bar/baz/quux"),
+				NewPath("foo/bar/baz/quux"),
 				PathPrefix("foo/bar"),
 				[]Name{},
 			)),
-			path: "fuga/piyo",
+			path: NewPath("fuga/piyo"),
 		},
 		{
 			name: "path is group itself",
 			rule: lo.Must(NewAntiAffinityGroupRule(
-				Path("foo/bar/baz/quux"),
+				NewPath("foo/bar/baz/quux"),
 				PathPrefix("foo/bar"),
 				[]Name{},
 			)),
-			path: "foo/bar",
+			path: NewPath("foo/bar"),
 		},
 		{
 			name: "path is not in selfPathPrefix but in allowNames",
 			rule: lo.Must(NewAntiAffinityGroupRule(
-				Path("foo/bar/baz/quux"),
+				NewPath("foo/bar/baz/quux"),
 				PathPrefix("foo/bar"),
 				[]Name{"hoge"},
 			)),
-			path: "foo/bar/hoge/piyo",
+			path: NewPath("foo/bar/hoge/piyo"),
+		},
+		{
+			name: "package suffix .test is ignored",
+			rule: lo.Must(NewAntiAffinityGroupRule(
+				NewPath("foo/bar/baz"),
+				PathPrefix("foo/bar"),
+				[]Name{""},
+			)),
+			path: NewPath("foo/bar/baz.test"),
 		},
 	}
 
@@ -161,11 +170,11 @@ func TestAntiAffinityGroupRuleCheckNG(t *testing.T) {
 		{
 			name: "path is in groupPathPrefix but not in selfPathPrefix",
 			rule: lo.Must(NewAntiAffinityGroupRule(
-				Path("foo/bar/baz/quux"),
+				NewPath("foo/bar/baz/quux"),
 				PathPrefix("foo/bar"),
 				[]Name{},
 			)),
-			path: "foo/bar/hoge/piyo",
+			path: NewPath("foo/bar/hoge/piyo"),
 			expected: &Violation{
 				ImportPath:  "foo/bar/hoge/piyo",
 				PackagePath: "foo/bar/baz/quux",
@@ -175,11 +184,11 @@ func TestAntiAffinityGroupRuleCheckNG(t *testing.T) {
 		{
 			name: "path is in groupPathPrefix but not in selfPathPrefix (path is in the same hierarchy as selfPathPrefix)",
 			rule: lo.Must(NewAntiAffinityGroupRule(
-				Path("foo/bar/baz/quux"),
+				NewPath("foo/bar/baz/quux"),
 				PathPrefix("foo/bar"),
 				[]Name{},
 			)),
-			path: "foo/bar/hoge",
+			path: NewPath("foo/bar/hoge"),
 			expected: &Violation{
 				ImportPath:  "foo/bar/hoge",
 				PackagePath: "foo/bar/baz/quux",
@@ -189,11 +198,11 @@ func TestAntiAffinityGroupRuleCheckNG(t *testing.T) {
 		{
 			name: "path has prefix selfPathPrefix literally but not in selfPathPrefix",
 			rule: lo.Must(NewAntiAffinityGroupRule(
-				Path("foo/bar/baz/quux"),
+				NewPath("foo/bar/baz/quux"),
 				PathPrefix("foo/bar"),
 				[]Name{},
 			)),
-			path: "foo/bar/baz123",
+			path: NewPath("foo/bar/baz123"),
 			expected: &Violation{
 				ImportPath:  "foo/bar/baz123",
 				PackagePath: "foo/bar/baz/quux",
@@ -222,7 +231,7 @@ func TestNewAntiAffinityListRule(t *testing.T) {
 		{
 			name:  "self is under a prefix",
 			label: "rule1",
-			self:  "foo/bar/baz/hoge",
+			self:  NewPath("foo/bar/baz/hoge"),
 			prefixes: []PathPrefix{
 				"foo/bar",
 				"fuga/piyo",
@@ -239,7 +248,7 @@ func TestNewAntiAffinityListRule(t *testing.T) {
 		{
 			name:  "self is same as a prefix",
 			label: "rule1",
-			self:  "foo/bar",
+			self:  NewPath("foo/bar"),
 			prefixes: []PathPrefix{
 				"foo/bar",
 				"fuga/piyo",
@@ -273,26 +282,26 @@ func TestAntiAffinityListRuleCheckOK(t *testing.T) {
 		{
 			name: "path does not match to any prefixes",
 			rule: lo.Must(NewAntiAffinityListRule(
-				Path("foo/bar/baz/quux"),
+				NewPath("foo/bar/baz/quux"),
 				[]PathPrefix{
 					"foo/bar",
 					"fuga/piyo",
 				},
 				"rule1",
 			)),
-			path: "quux",
+			path: NewPath("quux"),
 		},
 		{
 			name: "path matches a prefix but the prefix contains selfPath",
 			rule: lo.Must(NewAntiAffinityListRule(
-				Path("foo/bar/baz/quux"),
+				NewPath("foo/bar/baz/quux"),
 				[]PathPrefix{
 					"foo/bar",
 					"fuga/piyo",
 				},
 				"rule1",
 			)),
-			path: "foo/bar/quux",
+			path: NewPath("foo/bar/quux"),
 		},
 	}
 
@@ -314,14 +323,14 @@ func TestAntiAffinityListRuleCheckNG(t *testing.T) {
 		{
 			name: "path matches to a prefix",
 			rule: lo.Must(NewAntiAffinityListRule(
-				Path("foo/bar/baz/quux"),
+				NewPath("foo/bar/baz/quux"),
 				[]PathPrefix{
 					"foo/bar",
 					"fuga/piyo",
 				},
 				"rule1",
 			)),
-			path: "fuga/piyo/hoge",
+			path: NewPath("fuga/piyo/hoge"),
 			expected: &Violation{
 				ImportPath:  "fuga/piyo/hoge",
 				PackagePath: "foo/bar/baz/quux",
@@ -331,14 +340,14 @@ func TestAntiAffinityListRuleCheckNG(t *testing.T) {
 		{
 			name: "path matches to a prefix (path is same as the prefix)",
 			rule: lo.Must(NewAntiAffinityListRule(
-				Path("foo/bar/baz/quux"),
+				NewPath("foo/bar/baz/quux"),
 				[]PathPrefix{
 					"foo/bar",
 					"fuga/piyo",
 				},
 				"rule1",
 			)),
-			path: "fuga/piyo",
+			path: NewPath("fuga/piyo"),
 			expected: &Violation{
 				ImportPath:  "fuga/piyo",
 				PackagePath: "foo/bar/baz/quux",

--- a/pkg/importchecker/usecase/check_imports.go
+++ b/pkg/importchecker/usecase/check_imports.go
@@ -44,7 +44,7 @@ func NewCheckImportsInputPort(
 }
 
 func (it *checkImportsInteractor) Exec(in *CheckImportsInputData) error {
-	packagePath := domain.Path(in.PackagePath)
+	packagePath := domain.NewPath(in.PackagePath)
 	rules, err := it.antiAffinityRuleRepository.ListByPath(packagePath)
 	if err != nil {
 		return fmt.Errorf("failed to get anti affinity rules of package `%s`: %w", packagePath, err)
@@ -52,7 +52,7 @@ func (it *checkImportsInteractor) Exec(in *CheckImportsInputData) error {
 
 	violations := lo.FlatMap(in.ImportPaths, func(importPath string, _ int) []*domain.Violation {
 		return lo.Compact(lo.Map(rules, func(rule domain.AntiAffinityRule, _ int) *domain.Violation {
-			return rule.Check(domain.Path(importPath))
+			return rule.Check(domain.NewPath(importPath))
 		}))
 	})
 

--- a/pkgaffinity_test.go
+++ b/pkgaffinity_test.go
@@ -70,6 +70,10 @@ func TestAnalyzer(t *testing.T) {
 			name:        "package in ignorePaths",
 			packagePath: "a/foo/baz/ignored",
 		},
+		{
+			name:        "main and main.test are treated as the same package",
+			packagePath: "a/cmd/a",
+		},
 	}
 
 	for _, tt := range tests {

--- a/testdata/.pkgaffinity.yaml
+++ b/testdata/.pkgaffinity.yaml
@@ -6,6 +6,8 @@ antiAffinityRules:
         - allowed
       ignorePaths:
         - baz/ignored
+    # test for main.test package
+    - pathPrefix: a/cmd
   lists:
     - label: listrule1
       pathPrefixes:

--- a/testdata/src/a/cmd/a/main.go
+++ b/testdata/src/a/cmd/a/main.go
@@ -1,0 +1,3 @@
+package main
+
+func main() {}

--- a/testdata/src/a/cmd/a/main_test.go
+++ b/testdata/src/a/cmd/a/main_test.go
@@ -1,0 +1,5 @@
+package main
+
+import "testing"
+
+func TestMain(t *testing.T) {}


### PR DESCRIPTION
This fixes anti-affinity group rule false positives.